### PR TITLE
feature(auth): adding support for `Delegation Tokens` [FT-1800]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ comes with a set of additional features.
 * SASL support
   * PLAIN
   * SCRAM-SHA-256
+  * Delegation Tokens
 
 For these features to work you need a patched version of openresty. [See this source](https://github.com/Kong/kong-build-tools/tree/master/openresty-patches/patches/1.19.3.2)
 
@@ -196,7 +197,8 @@ client config
             strategy = "sasl", 
             mechanism="PLAIN", -- [oneOf = ['PLAIN', 'SCRAM-SHA-256']]
             user="admin", 
-            password="admin-secret"
+            password="admin-secret",
+            tokenauth="true" -- <bool> needs to be "true" when authenticating with delegation tokens, defaults to "false"
             }
     ```
     All seen fields are required.

--- a/dev/delegation_token.sh
+++ b/dev/delegation_token.sh
@@ -1,2 +1,2 @@
-docker-compose exec broker kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:user1
-docker-compose exec broker kafka-delegation-tokens --bootstrap-server broker:29093 --describe --command-config /etc/kafka/client.config --owner-principal User:user1
+docker-compose exec broker kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:admin
+docker-compose exec broker kafka-delegation-tokens --bootstrap-server broker:29093 --describe --command-config /etc/kafka/client.config --owner-principal User:admin

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
 
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
 
-      # KAFKA_DELEGATION_TOKEN_MASTER_KEY: 'foo'
+      KAFKA_DELEGATION_TOKEN_MASTER_KEY: 'foo'
 
       # 'requested' for TLS
       # KAFKA_SSL_CLIENT_AUTH: requested


### PR DESCRIPTION

According to [KIP-48-Delegation-tokens](https://cwiki.apache.org/confluence/display/KAFKA/KIP-48+Delegation+token+support+for+Kafka#KIP48DelegationtokensupportforKafka-AuthenticationusingDelegationToken)

```
SCRAM Extensions
SCRAM messages have an optional extensions field which is a comma-separated list of key=value pairs.
After KIP-84 implementation , an extension will be added to the first client SCRAM message to indicate
that authentication is being requested for a delegation token. This will enable Kafka broker to obtain
credentials and principal using a different code path for delegation tokens.
```

Folling the `Formal syntax` part of the SCRAM RFC (https://datatracker.ietf.org/doc/html/rfc5802#section-7)

this looks like:


```
   client-first-message-bare =
                     [reserved-mext ","]
                     username "," nonce ["," extensions]
```


TODO:

* Tokens are ephemeral and can't be created before spawning the cluster. This means we need to come up with a way to generate them and inject them into the testbed.
  * tokens are currently generated with the `delegation_tokens.sh` script in `dev/`