### PR TITLE
feat(producer): negotiate lowest supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,21 @@ or
 
 from here on, you can run `busted` to trigger the tests.
 
+Microsoft Eventhub Testing
+----------------
+
+In order to run tests against EventHub you have to set two environment variabels:
+
+* `EVENTHUB_HOST`
+
+Set this variable to what you'd set the `bootstrap.servers` value
+
+* `EVENTHUB_CREDENTIALS`
+
+Set this variable to what you'd set the `password` string (sometimes referred to `YOUR.EVENTHUBS.CONNECTION.STRING`)
+
+If both of these variables are set, tests also run against the configured endpoint.
+
 Author
 ======
 

--- a/lib/resty/kafka/broker.lua
+++ b/lib/resty/kafka/broker.lua
@@ -15,7 +15,8 @@ local mt = { __index = _M }
 
 
 local function _sock_send_receive(sock, request)
-    local bytes, err = sock:send(request:package())
+    local req = request:package()
+    local bytes, err = sock:send(req)
     if not bytes then
         return nil, err, true
     end

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -40,7 +40,8 @@ end
 
 local function metadata_encode(client_id, topics, num, api_version)
     local id = 0    -- hard code correlation_id
-    local req = request:new(request.MetadataRequest, id, client_id, api_version)
+    local _api_version = api_version or 0
+    local req = request:new(request.MetadataRequest, id, client_id, _api_version)
 
     req:int32(num)
 

--- a/lib/resty/kafka/errors.lua
+++ b/lib/resty/kafka/errors.lua
@@ -20,7 +20,8 @@ local _M = {
     [15]    = 'ConsumerCoordinatorNotAvailableCode',
     [16]    = 'NotCoordinatorForConsumerCode',
     [34]    = 'IllegalSaslState',
-    [63]    = 'DelegationTokenOwnerMisMatch'
+    [63]    = 'DelegationTokenOwnerMisMatch',
+    [87]    = 'InvalidRecord'
 }
 
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -338,6 +338,9 @@ local function negotiate_api_version(supported_version_map, api_key, max_support
     -- use this if exists. Fail if min_version >= max_supported version.
 
     local version_map = supported_version_map[api_key]
+    if not version_map then
+        return nil, "Could not retrieve version map from cluster"
+    end
     local min_version = version_map.min_version
     if min_version > max_supported_ver then
         return nil, "This library does not support the minumum required API version("..min_version..") that your Kafka cluster accepts ("..max_supported_ver..")"

--- a/lib/resty/kafka/request.lua
+++ b/lib/resty/kafka/request.lua
@@ -40,6 +40,7 @@ _M.CreateDelegationTokenRequest = 38
 
 
 
+
 local function str_int8(int)
     return char(band(int, 0xff))
 end
@@ -193,7 +194,7 @@ end
 
 local function message_package(key, msg, message_version)
     -- Messages are not Records (or MessageSets are not RecordBatches)
-    local key = key or "key"
+    local key = key or ""
     local key_len = #key
     local len = #msg
 
@@ -239,7 +240,7 @@ function _M.message_set(self, messages, index)
     local index = index or #messages
 
     local message_version = MESSAGE_VERSION_0
-    if self.api_key == _M.ProduceRequest and (self.api_version == _M.API_VERSION_V2 or self.api_version == _M.API_VERSION_V3) then
+    if self.api_key == _M.ProduceRequest then
         message_version = MESSAGE_VERSION_1
     end
 
@@ -269,6 +270,5 @@ function _M.package(self)
 
     return req
 end
-
 
 return _M

--- a/lib/resty/kafka/request.lua
+++ b/lib/resty/kafka/request.lua
@@ -24,6 +24,7 @@ local MESSAGE_VERSION_1 = 1
 _M.API_VERSION_V0 = 0
 _M.API_VERSION_V1 = 1
 _M.API_VERSION_V2 = 2
+_M.API_VERSION_V3 = 3
 
 _M.ProduceRequest = 0
 _M.FetchRequest = 1
@@ -60,9 +61,9 @@ end
 
 local function str_nullable_str(str)
     if not str or #str == 0 then
-        return str_int16(-1) ,2
+        return str_int16(-1), 2
     else
-        return  str ,#str
+        return str, #str
     end
 end
 
@@ -143,6 +144,27 @@ function _M.int64(self, int)
 end
 
 
+function _M.nullable_str(self, str)
+    local req = self._req
+    local offset = self.offset
+    local str_len
+    local val
+    if not str or #str == 0 then
+        val = str_int16(-1)
+        str_len = 2
+    else
+        val = str
+        str_len = #str
+    end
+
+    req[offset] = str_int16(str_len)
+    req[offset + 1] = val
+
+    self.offset = offset + 2
+    -- extend the length for a int16 and the length of the string
+    self.len = self.len + 2 + str_len
+end
+
 function _M.string(self, str)
     local req = self._req
     local offset = self.offset
@@ -171,7 +193,7 @@ end
 
 local function message_package(key, msg, message_version)
     -- Messages are not Records (or MessageSets are not RecordBatches)
-    local key = key or ""
+    local key = key or "key"
     local key_len = #key
     local len = #msg
 
@@ -183,6 +205,7 @@ local function message_package(key, msg, message_version)
             str_int8(1),
             -- XX hard code no Compression
             str_int8(0),
+            -- timestamp
             str_int64(ffi.new("int64_t", (os.time() * 1000))), -- timestamp
             str_int32(key_len),
             key,
@@ -198,7 +221,6 @@ local function message_package(key, msg, message_version)
             -- XX hard code no Compression
             str_int8(0),
             str_int32(key_len),
-            key,
             str_int32(len),
             msg,
         }
@@ -217,7 +239,7 @@ function _M.message_set(self, messages, index)
     local index = index or #messages
 
     local message_version = MESSAGE_VERSION_0
-    if self.api_key == _M.ProduceRequest and self.api_version == API_VERSION_V2 then
+    if self.api_key == _M.ProduceRequest and (self.api_version == _M.API_VERSION_V2 or self.api_version == _M.API_VERSION_V3) then
         message_version = MESSAGE_VERSION_1
     end
 

--- a/spec/event_hub_spec.lua
+++ b/spec/event_hub_spec.lua
@@ -1,27 +1,37 @@
+
 local client = require "resty.kafka.client"
 local producer = require "resty.kafka.producer"
 local key = KEY
 local message = MESSAGE
+local os = os
+
+local eventhub_credentials = os.getenv("EVENTHUB_CREDENTIALS")
+local eventhub_host = os.getenv("EVENTHUB_HOST")
 
 local broker_list_sasl = {
-    { host = "broker", port = 19093 },
+    { host = eventhub_host, port = 9093 },
 }
 local sasl_config = { strategy="sasl",
                       mechanism="PLAIN",
-                      user="admin",
-                      password="admin-secret" }
+                      user="$ConnectionString",
+                      password=eventhub_credentials
+                    }
 local client_config_sasl_plain = {
-    ssl = false,
+    ssl = true,
     auth_config = sasl_config
 }
 
 local cli
 
-describe("Testing sasl plain client", function()
+if not (eventhub_credentials and eventhub_host) then
+  -- do not run this file if eventhub isn't configured
+  return true
+end
+
+describe("Testing Microsoft EventHub", function()
 
   before_each(function()
       cli = client:new(broker_list_sasl, client_config_sasl_plain)
-      create_topics()
   end)
 
   it("to build the metatable correctly", function()
@@ -34,21 +44,20 @@ describe("Testing sasl plain client", function()
 
   it("to fetch metadata correctly", function()
     -- Fetch metadata
-    local brokers, partitions = cli:fetch_metadata(TEST_TOPIC)
-    assert.are.same({{host = "broker", port = 19093}}, brokers)
-    -- Check if return is as expected
-    assert.are.same({{host = "broker", port = 19093}}, cli.brokers)
+    local brokers, partitions = cli:fetch_metadata("konglog")
+    assert.are.equal(brokers[0].host, eventhub_host)
+    assert.are.equal(brokers[0].port, 9093)
     -- Check if return was assigned to cli metatable
-    assert.are.same({errcode = 0, id = 0, isr = {1}, leader = 1, replicas = {1}},partitions[0])
+    assert.are.same({errcode = 0, id = 0, isr = {}, leader = 0, replicas = {}},partitions[0])
     -- Check if partitions were fetched correctly
-    assert.is_not_nil(cli.topic_partitions[TEST_TOPIC])
+    assert.is_not_nil(cli.topic_partitions["konglog"])
     -- Check if cli partitions metatable was set correctly
   end)
 
   it("setup producers correctly", function()
     local p, err = producer:new(broker_list_sasl, client_config_sasl_plain)
     assert.is_nil(err)
-    local offset, err = p:send("test", key, message)
+    local offset, err = p:send("konglog", key, message)
     assert.is_nil(err)
     assert.is_number(tonumber(offset))
   end)

--- a/spec/producer_spec.lua
+++ b/spec/producer_spec.lua
@@ -10,13 +10,6 @@ describe("Test producers: ", function()
       create_topics()
   end)
 
-  it("only allows ProducerAPI version <=2", function()
-    local p, err = producer:new(broker_list_plain, {api_version=3})
-    assert.is_nil(p)
-    assert.is_not_nil(err)
-    assert.is.same(err, "The highest supported Producer API version is 2")
-  end)
-
   it("sends two messages and the offset is one apart", function()
     local p, err = producer:new(broker_list_plain)
     assert.is_nil(err)


### PR DESCRIPTION
This is mainly for compatibility with Microsoft EventHub.

EventHub's `min_version` for Kafka's `ProduceAPI` is 3 (at the time writing)

This library technically supports version 1..3. Kafka however expects a different messaging format from ProduceV3 onwards. (RecordBatch vs. MessageSet). EventHub still accepts the old message format though.

The strategy here is to always use to _lowest_(min_version) possible version of a producer that a cluster supports to ensure that _actual_ Kafka clusters fall back to version 0 or 1.


internal: https://konghq.atlassian.net/browse/FTI-3165