### PR TITLE
avoid cached producer when cluster config is changed (FTI-4663)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,10 +6,10 @@ on:
     branches: [master]
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: set permissions 
+      - name: set permissions
         run: sudo chown -R $(id -u):$(id -g) dev/tokens
       - name: Setup environment
         run: make devup

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ setup-certs:
 devup: setup-certs
 	docker-compose -f dev/docker-compose.yaml  -f dev/docker-compose.dev.yaml up -d
 
-test: devup
+test:
 	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T openresty luarocks make
 	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty busted
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-OPENRESTY_PREFIX=/usr/local/openresty-debug
-
+OPENRESTY_PREFIX=/usr/local/openresty
 SHELL := /bin/bash
 PREFIX ?=          /usr/local
 LUA_INCLUDE_DIR ?= $(PREFIX)/include

--- a/dev/docker-compose.dev.yaml
+++ b/dev/docker-compose.dev.yaml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   openresty:
-    build: openresty/
+    build: ./openresty
     container_name: dev_openresty
     hostname: test
     depends_on:
@@ -9,12 +9,24 @@ services:
     ports:
       - "8080:8081"
     volumes:
-      - ../../lua-resty-kafka:/usr/local/lib/lua/lua-resty-kafka
-      - ./openresty/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
-      - ./openresty/nginx.conf.d/:/usr/local/openresty/nginx/conf/conf.d/
-      - ./keystore/combined.key:/certs/combined.crt
-      - ./keystore/privkey.key:/certs/privkey.key
-      - ./keystore/certchain.crt:/certs/certchain.crt
+      - type: bind
+        source: ./openresty/nginx.conf
+        target: /usr/local/openresty/nginx/conf/nginx.conf
+      - type: bind
+        source: ./openresty/nginx.conf.d/
+        target: /usr/local/openresty/nginx/conf/conf.d/
+      - type: bind
+        source: ./keystore/combined.key
+        target: /certs/combined.crt
+      - type: bind
+        source: ./keystore/privkey.key
+        target: /certs/privkey.key
+      - type: bind
+        source: ./keystore/certchain.crt
+        target: /certs/certchain.crt
+      - type: bind
+        source: ../
+        target: /usr/local/lib/lua/lua-resty-kafka/
     networks:
       kafka:
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -21,12 +21,15 @@ services:
     image: confluentinc/cp-kafka:6.2.0
     networks:
       kafka:
-    depends_on:
-    - broker
     command: >
      /bin/bash -c "
-       kafka-configs --bootstrap-server broker:9092 --alter --add-config 'SCRAM-SHA-256 =[iterations=4096,password=client-password]' --entity-type users --entity-name client;
-       kafka-configs --bootstrap-server broker:9092 --alter --add-config 'SCRAM-SHA-512 =[iterations=4096,password=client-password]' --entity-type users --entity-name client-sha512;"
+        while ! nc -z broker 9092;
+        do
+          echo sleeping;
+          sleep 1;
+        done;
+        kafka-configs --bootstrap-server broker:9092 --alter --add-config 'SCRAM-SHA-256 =[iterations=4096,password=client-password]' --entity-type users --entity-name client;
+        kafka-configs --bootstrap-server broker:9092 --alter --add-config 'SCRAM-SHA-512 =[iterations=4096,password=client-password]' --entity-type users --entity-name client-sha512;"
     healthcheck:
       test: nc -z broker 9092
 
@@ -34,12 +37,15 @@ services:
     image: confluentinc/cp-kafka:6.2.0
     networks:
       kafka:
-    depends_on:
-    - broker
     user: root
     command: >
      /bin/bash -c "
-       kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:admin | awk '/TOKENID/{getline; print}' | tr ' ' '\n'| head -2 > /etc/kafka/tokens/delegation-tokens.env"
+        while ! nc -z broker 9092;
+        do
+          echo sleeping;
+          sleep 1;
+        done;
+        kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:admin | awk '/TOKENID/{getline; print}' | tr ' ' '\n'| head -2 > /etc/kafka/tokens/delegation-tokens.env"
     healthcheck:
       test: nc -z broker 9092
     volumes:

--- a/dev/kafka-generate-ssl-automatic.sh
+++ b/dev/kafka-generate-ssl-automatic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# set -eu    # debug only
+set -eu
 
 KEYSTORE_FILENAME="kafka.keystore.jks"
 CLIENT_KEYSTORE_FILENAME="client.keystore.jks"
@@ -24,7 +24,7 @@ PASS="confluent"
 
 function file_exists_and_exit() {
   echo "'$1' cannot exist. Move or delete it before"
-  echo "you are re-running this script."
+  echo "re-running this script."
   exit 1
 }
 

--- a/dev/kafka-generate-ssl-automatic.sh
+++ b/dev/kafka-generate-ssl-automatic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+# set -eu    # debug only
 
 KEYSTORE_FILENAME="kafka.keystore.jks"
 CLIENT_KEYSTORE_FILENAME="client.keystore.jks"
@@ -24,7 +24,7 @@ PASS="confluent"
 
 function file_exists_and_exit() {
   echo "'$1' cannot exist. Move or delete it before"
-  echo "re-running this script."
+  echo "you are re-running this script."
   exit 1
 }
 
@@ -96,7 +96,7 @@ trust_store_private_key_file=""
 
   # don't need the cert because it's in the trust store.
   # PATCH: I do
-  # rm $TRUSTSTORE_WORKING_DIRECTORY/$CA_CERT_FILE
+  # rm -f $TRUSTSTORE_WORKING_DIRECTORY/$CA_CERT_FILE
 
 echo
 echo "Continuing with:"
@@ -158,7 +158,7 @@ do
   echo
   keytool -keystore $KEYSTORE_WORKING_DIRECTORY/$keystore -alias CARoot \
     -import -file $CA_CERT_FILE -keypass $PASS -storepass $PASS -noprompt
-  rm $CA_CERT_FILE # delete the trust store cert because it's stored in the trust store.
+  rm -f $CA_CERT_FILE # delete the trust store cert because it's stored in the trust store.
 
   echo
   echo "Now the keystore's signed certificate will be imported back into the keystore."
@@ -176,9 +176,9 @@ do
   echo " - '$KEYSTORE_SIGNED_CERT': the keystore's certificate, signed by the CA, and stored back"
   echo "    into the keystore"
 
-    rm $KEYSTORE_SIGN_REQUEST_SRL
-    rm $KEYSTORE_SIGN_REQUEST
-    rm $KEYSTORE_SIGNED_CERT
+    rm -f $KEYSTORE_SIGN_REQUEST_SRL
+    rm -f $KEYSTORE_SIGN_REQUEST
+    rm -f $KEYSTORE_SIGNED_CERT
 
 
 done

--- a/dev/openresty/Dockerfile
+++ b/dev/openresty/Dockerfile
@@ -19,12 +19,12 @@ RUN  wget https://openresty.org/download/openresty-1.19.3.2.tar.gz \
   && tar zxvf openresty-1.19.3.2.tar.gz \
   && wget https://github.com/Kong/kong-build-tools/archive/master.tar.gz \
   && tar zvfx master.tar.gz \
-  && cd openresty-1.19.3.2/bundle \ 
+  && cd openresty-1.19.3.2/bundle \
   && for i in ../../kong-build-tools-master/openresty-patches/patches/1.19.3.2/*.patch; do patch -p1 < $i; done \
   && cd ../ \
   && ./configure --with-luajit  --with-http_addition_module --with-http_dav_module --with-http_geoip_module --with-http_gzip_static_module --with-http_image_filter_module --with-http_realip_module --with-http_stub_status_module --with-http_ssl_module --with-http_sub_module --with-http_xslt_module --with-ipv6 --with-http_postgres_module --with-pcre-jit \
   && make \
-  && make install 
+  && make install
 
 
 ENV PATH $PATH:/usr/local/openresty/nginx/sbin
@@ -33,9 +33,9 @@ COPY ./reload_nginx.sh /usr/local/openresty/bin/nginxReloader.sh
 COPY ./docker-entrypoint.sh /usr/local/openresty/bin/docker-entrypoint.sh
 
 
-RUN wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz 
+RUN wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz
 RUN tar zxpf luarocks-3.3.1.tar.gz && cd luarocks-3.3.1 && ./configure && make && make install
-RUN luarocks install busted 
+RUN luarocks install busted
 RUN luarocks install inspect
 RUN luarocks install lua-resty-openssl
 

--- a/kong-lua-resty-kafka-0.14-0.rockspec
+++ b/kong-lua-resty-kafka-0.14-0.rockspec
@@ -31,7 +31,8 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "lua-resty-openssl"
+   "lua-resty-openssl",
+   "penlight == 1.13.1",
 }
 build = {
    type = "builtin",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -9,19 +9,22 @@ local broker_list_plain = {
 
 local f, cert_data, key_data, cert, priv_key, _
 -- Load certificate
-repeat
-  f = assert(io.open("/certs/certchain.crt"))
-  cert_data = f:read("*a")
-  f:close()
-until cert_data
+
+f = assert(io.open("/certs/certchain.crt"))
+cert_data = f:read("*a")
+f:close()
+if not cert_data then
+  print("failed to read cert data from file")
+end
 cert, _ = ssl.parse_pem_cert(cert_data)
 
 -- Load private key
-repeat
-  f = assert(io.open("/certs/privkey.key"))
-  key_data = f:read("*a")
-  f:close()
-until key_data
+f = assert(io.open("/certs/privkey.key"))
+key_data = f:read("*a")
+f:close()
+if not key_data then
+  print("failed to read key data from file")
+end
 priv_key, _ = ssl.parse_pem_priv_key(key_data)
 
 -- move to fixture dir or helper file

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -15,6 +15,7 @@ cert_data = f:read("*a")
 f:close()
 if not cert_data then
   print("failed to read cert data from file")
+  print(os.execute(string.format("cat %s", "/certs/certchain.crt")))
 end
 cert, _ = ssl.parse_pem_cert(cert_data)
 

--- a/spec/producer_spec.lua
+++ b/spec/producer_spec.lua
@@ -55,7 +55,7 @@ describe("Test producers: ", function()
   it("avoid cached producer when cluster config is updated", function()
     local producer_config = { producer_type = "async" }
     local cluster_name = "kong"
-    local p1, p2, p3, p4, err
+    local p1, p2, p3, p4, p5, err
 
     p1, err = producer:new(broker_list_plain, producer_config, cluster_name)
     assert.is_nil(err)
@@ -77,6 +77,12 @@ describe("Test producers: ", function()
     p4, err = producer:new(broker_list_plain_dup, producer_config, cluster_name)
     assert.is_nil(err)
     assert.are.equal(p4, p1)
+
+    -- avoid cache and create new
+    local broker_list_plain_dup = tx_deepcopy(broker_list_plain)
+    p5, err = producer:new(broker_list_plain_dup, { request_timeout = 1000 } , cluster_name)
+    assert.is_nil(err)
+    assert.are_not.equals(p5, p1)
   end)
 
   it("sends two messages to two different topics", function()

--- a/spec/producer_spec.lua
+++ b/spec/producer_spec.lua
@@ -55,7 +55,7 @@ describe("Test producers: ", function()
   it("avoid cached producer when cluster config is updated", function()
     local producer_config = { producer_type = "async" }
     local cluster_name = "kong"
-    local p1, p2, p3, err
+    local p1, p2, p3, p4, err
 
     p1, err = producer:new(broker_list_plain, producer_config, cluster_name)
     assert.is_nil(err)
@@ -67,11 +67,16 @@ describe("Test producers: ", function()
     assert.is_nil(p2)
     assert.are.equal("Could not retrieve version map from cluster", err)
 
+    -- empty broker list
+    p3, err = producer:new(nil, producer_config, cluster_name)
+    assert.is_nil(p3)
+    assert.are.equal("Could not retrieve version map from cluster", err)
+
     -- reuse cache
     local broker_list_plain_dup = tx_deepcopy(broker_list_plain)
-    p3, err = producer:new(broker_list_plain_dup, producer_config, cluster_name)
+    p4, err = producer:new(broker_list_plain_dup, producer_config, cluster_name)
     assert.is_nil(err)
-    assert.are.equal(p3, p1)
+    assert.are.equal(p4, p1)
   end)
 
   it("sends two messages to two different topics", function()


### PR DESCRIPTION
Avoid cached producer when cluster config is changed (FTI-4663)

1. Fix test Ubuntu image to `22.04`.
2. Make sure SASL SCRAM is added to Kafka.
3. Bypass producer cache if the Kakfa cluster config is changed. Reuse producer cache if the config is applied.
4. Improve `spec/helpers.lua`.

The CI fails. So there are a few fixes in CI to make tests pass.

Deprecates https://github.com/Kong/kong-ee/pull/4503