### PR TITLE
fix(sasl) remove extra argument to x509:digest and fix signature name

### DIFF
--- a/lib/resty/kafka/auth/strategies/sasl.lua
+++ b/lib/resty/kafka/auth/strategies/sasl.lua
@@ -124,8 +124,13 @@ local function be_tls_get_certificate_hash(sock)
 
     signature = signature:lower()
 
-    if signature:match("md5") or signature:match("sha1") then
+    if signature:match("^md5") or signature:match("^sha1") or signature:match("sha1$") or signature:match("sha256$") then
         signature = "sha256"
+    else
+        local objects = require("resty.openssl.objects")
+        local sigid = assert(objects.txt2nid(signature))
+        local digest_nid = assert(objects.find_sigid_algs(sigid))
+        signature = assert(objects.nid2table(digest_nid).sn)
     end
 
     local openssl_x509 = require("resty.openssl.x509").new(pem, "PEM")

--- a/lib/resty/kafka/auth/strategies/sasl.lua
+++ b/lib/resty/kafka/auth/strategies/sasl.lua
@@ -130,7 +130,7 @@ local function be_tls_get_certificate_hash(sock)
 
     local openssl_x509 = require("resty.openssl.x509").new(pem, "PEM")
 
-    local openssl_x509_digest, err = openssl_x509:digest(signature, "s")
+    local openssl_x509_digest, err = openssl_x509:digest(signature)
 
     if not (openssl_x509_digest) then
     return nil, tostring(err)

--- a/lib/resty/kafka/auth/strategies/sasl.lua
+++ b/lib/resty/kafka/auth/strategies/sasl.lua
@@ -130,13 +130,7 @@ local function be_tls_get_certificate_hash(sock)
 
     local openssl_x509 = require("resty.openssl.x509").new(pem, "PEM")
 
-    local openssl_x509_digest, err = openssl_x509:digest(signature)
-
-    if not (openssl_x509_digest) then
-    return nil, tostring(err)
-    end
-
-    return openssl_x509_digest
+    return openssl_x509:digest(signature)
 end
 
 local function hmac(key, str, hf)
@@ -325,7 +319,10 @@ local function _sasl_auth(self, sock)
         end
 
 
-        local cbind_data = be_tls_get_certificate_hash(sock)
+        local cbind_data, err = be_tls_get_certificate_hash(sock)
+        if err then
+            return nil, "failed to calculate certificate hash " .. err
+        end
 
         cbind_input = gs2_header .. cbind_data
 


### PR DESCRIPTION
The second argument starts to have meaning when used with openssl 3.0 and reveals the bug.

Also ported signature name fix from https://github.com/Kong/pgmoon/commit/54f7c72164985453a43d6f97c1e29f36fadb7182