### PR TITLE
chore(release): bump version to 0.18

### DIFF
--- a/kong-lua-resty-kafka-0.18-0.rockspec
+++ b/kong-lua-resty-kafka-0.18-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-lua-resty-kafka"
-version = "0.17-0"
+version = "0.18-0"
 source = {
    url = "git+https://github.com/Kong/lua-resty-kafka",
-   tag = "v0.17"
+   tag = "v0.18"
 }
 description = {
    summary = "Lua Kafka client driver for the ngx_lua based on the cosocket API",

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -21,7 +21,7 @@ if not ok then
 end
 
 
-local _M = { _VERSION = "0.17" }
+local _M = { _VERSION = "0.18" }
 local mt = { __index = _M }
 
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -39,7 +39,7 @@ if not ok then
 end
 
 
-local _M = { _VERSION = "0.17" }
+local _M = { _VERSION = "0.18" }
 local mt = { __index = _M }
 
 


### PR DESCRIPTION
To fix an issue that the lib cannot do TLS handshake when connecting Kafka server via TCP/TLS proxy.