### PR TITLE
feat(client): allow client_id overrides

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,12 @@ jobs:
       - name: Create delegation tokens
         run: make delegation-token
       - name: Run busted tests
+        env:
+          CONFLUENT_BOOTSTRAP_SERVER: ${{ secrets.KONG_SPEC_TEST_CONFLUENT_HOST }}
+          CONFLUENT_BOOTSTRAP_PORT: ${{ secrets.KONG_SPEC_TEST_CONFLUENT_PORT }}
+          CONFLUENT_API_KEY: ${{ secrets.KONG_SPEC_TEST_CONFLUENT_CLUSTER_API_KEY }}
+          CONFLUENT_API_SECRET: ${{ secrets.KONG_SPEC_TEST_CONFLUENT_CLUSTER_API_SECRET }}
+          CONFLUENT_TOPIC: ${{ secrets.KONG_SPEC_TEST_CONFLUENT_TOPIC }}
         run: make test
       - name: Get logs
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,16 @@ LUA_INCLUDE_DIR ?= $(PREFIX)/include
 LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
 INSTALL ?= install
 
-TOKENID := $(shell sed -n 1p dev/tokens/delegation-tokens.env)
-TOKENHMAC := $(shell sed -n 2p dev/tokens/delegation-tokens.env)
+TOKENID := $(shell awk '{print $$1}' dev/tokens/delegation-tokens.env)
+TOKENHMAC := $(shell awk '{print $$2}' dev/tokens/delegation-tokens.env)
 
 .PHONY: all install
+
+# Check if docker-compose is installed, fall back to `docker compose` if not
+COMPOSE_BIN := $(shell command -v docker-compose 2> /dev/null)
+ifeq ($(COMPOSE_BIN),)
+	COMPOSE_BIN := docker compose
+endif
 
 
 all: ;
@@ -24,23 +30,23 @@ setup-certs:
 	cd dev/; bash kafka-generate-ssl-automatic.sh; cd -
 
 devup: setup-certs
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml up -d
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic test --replica-assignment 1
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic test1 --replica-assignment 1
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic brokerdown --replica-assignment 2
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml up -d
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic test --replica-assignment 1
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic test1 --replica-assignment 1
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T broker kafka-topics --bootstrap-server broker:9092 --create --topic brokerdown --replica-assignment 2
 
 test:
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T openresty luarocks make
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty busted
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T openresty luarocks make
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty busted
 
 devdown:
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml down --remove-orphans
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml down --remove-orphans
 
-devshell: delegation-token
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty /bin/bash
+devshell:
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty /bin/bash
 
 devlogs:
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml logs
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml logs
 
 delegation-token:
-	docker-compose -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml run create-delegation-token
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml run create-delegation-token

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ devup: setup-certs
 
 test:
 	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T openresty luarocks make
-	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) openresty busted
+	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml exec -T                                           \
+								 -e TOKENID=$(TOKENID) -e TOKENHMAC=$(TOKENHMAC) -e CONFLUENT_BOOTSTRAP_SERVER=$(CONFLUENT_BOOTSTRAP_SERVER) \
+								 -e CONFLUENT_BOOTSTRAP_PORT=$(CONFLUENT_BOOTSTRAP_PORT) -e CONFLUENT_API_KEY=$(CONFLUENT_API_KEY)           \
+								 -e CONFLUENT_API_SECRET=$(CONFLUENT_API_SECRET) -e CONFLUENT_TOPIC=$(CONFLUENT_TOPIC) openresty busted
 
 devdown:
 	$(COMPOSE_BIN) -f dev/docker-compose.yaml -f dev/docker-compose.dev.yaml down --remove-orphans

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of Contents
   - [resty.kafka.client](#restykafkaclient)
     - [Methods](#methods)
       - [new](#new)
-      - [fetch_metadata](#fetch_metadata)
+      - [fetch\_metadata](#fetch_metadata)
       - [refresh](#refresh)
   - [resty.kafka.producer](#restykafkaproducer)
     - [Methods](#methods-1)

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
           echo sleeping;
           sleep 1;
         done;
-        kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:admin | awk '/TOKENID/{getline; print}' | tr ' ' '\n'| head -2 > /etc/kafka/tokens/delegation-tokens.env"
+        kafka-delegation-tokens --bootstrap-server broker:29093 --create --max-life-time-period -1 --command-config /etc/kafka/client.config --renewer-principal User:admin | awk '/TOKENID/{getline; print}' > /etc/kafka/tokens/delegation-tokens.env"
     healthcheck:
       test: nc -z broker 9092
     volumes:
@@ -59,6 +59,7 @@ services:
   broker:
     image: confluentinc/cp-kafka:6.2.0
     hostname: broker
+    container_name: broker
     depends_on:
       - zookeeper
     healthcheck:
@@ -126,6 +127,7 @@ services:
   broker2:
     image: confluentinc/cp-kafka:6.2.0
     hostname: broker2
+    container_name: broker2
     depends_on:
       - zookeeper
     healthcheck:
@@ -227,6 +229,6 @@ services:
           - "kafkaproxy"
     volumes:
       - ./kong/kong.yaml:/kong/kong.yaml
-      
+
 networks:
     kafka:

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -239,7 +239,7 @@ function _M.new(self, broker_list, client_config)
         topic_partitions = {},
         brokers = {},
         supported_api_versions = {},
-        client_id = "worker" .. pid(),
+        client_id = opts.client_id or ("worker" .. pid()),
         socket_config = socket_config,
         auth_config = opts.auth_config or nil,
     }, mt)

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -1,0 +1,16 @@
+local client = require "resty.kafka.client"
+
+describe("Client", function()
+
+  describe(":new", function()
+    it("accepts a client_id", function()
+      local c = client:new({ host = "foo", port = 123 }, { client_id = "test-override" })
+      assert.are.equal("test-override", c.client_id)
+    end)
+
+    it("defaults to a computed value when client_id is not provided", function()
+      local c = client:new({ host = "foo", port = 123 }, { client_id = nil })
+      assert.matches("worker%d", c.client_id)
+    end)
+  end)
+end)

--- a/spec/confluent_spec.lua
+++ b/spec/confluent_spec.lua
@@ -53,15 +53,18 @@ describe("Testing Confluent Cloud", function()
     assert.is_not_nil(brokers)
     assert.is_same("b0-" .. confluent_bootstrap_server_adr, brokers[0].host)
     assert.are.equal(brokers[0].port, 9092)
+
+    local first_partition = partitions[0]
+    table.sort(first_partition.replicas)
+    table.sort(first_partition.isr)
     -- Check if return was assigned to cli metatable
     assert.are.same({
                   errcode = 0,
                   id = 0,
                   leader = 4,
-                  replicas = { [1] = 4, [2] = 5, [3] = 0},
-                  isr = { [1] = 4, [2] = 5, [3] = 0},
-                  }
-                    ,partitions[0])
+                  replicas = { [1] = 0, [2] = 4, [3] = 5},
+                  isr = { [1] = 0, [2] = 4, [3] = 5},
+                  }, first_partition)
     -- Check if partitions were fetched correctly
     assert.is_not_nil(cli.topic_partitions[confluent_topic])
     -- Check if cli partitions metatable was set correctly

--- a/spec/confluent_spec.lua
+++ b/spec/confluent_spec.lua
@@ -1,0 +1,77 @@
+
+local client = require "resty.kafka.client"
+local producer = require "resty.kafka.producer"
+local key = KEY
+local message = MESSAGE
+local os = os
+
+local confluent_bootstrap_server_adr = os.getenv("CONFLUENT_BOOTSTRAP_SERVER")
+local confluent_bootstrap_server_port = os.getenv("CONFLUENT_BOOTSTRAP_PORT")
+local confluent_api_key = os.getenv("CONFLUENT_API_KEY")
+local confluent_api_secret = os.getenv("CONFLUENT_API_SECRET")
+local confluent_topic = os.getenv("CONFLUENT_TOPIC")
+
+local broker_list_sasl = {
+    { host = confluent_bootstrap_server_adr, port = confluent_bootstrap_server_port },
+}
+local sasl_config = { strategy="sasl",
+                      mechanism="PLAIN",
+                      user = confluent_api_key,
+                      password = confluent_api_secret
+                    }
+local client_config_sasl_plain = {
+    ssl = true,
+    auth_config = sasl_config,
+    client_id =  "test-override"
+}
+
+local cli
+
+if not (confluent_api_key and confluent_api_secret) then
+  -- do not run this file if confluent isn't configured
+  return true
+end
+
+describe("Testing Confluent Cloud", function()
+
+  before_each(function()
+      cli = client:new(broker_list_sasl, client_config_sasl_plain)
+  end)
+
+  it("to build the metatable correctly", function()
+    assert.are.equal(cli.socket_config.ssl, client_config_sasl_plain.ssl)
+    assert.are.equal(cli.socket_config.ssl_verify, false)
+    assert.are.equal(cli.auth_config.mechanism, sasl_config.mechanism)
+    assert.are.equal(cli.auth_config.user, sasl_config.user)
+    assert.are.equal(cli.auth_config.password, sasl_config.password)
+    assert.are.equal(cli.client_id, client_config_sasl_plain.client_id)
+  end)
+
+  it("to fetch metadata correctly", function()
+    -- Fetch metadata
+    local brokers, partitions = cli:fetch_metadata(confluent_topic)
+    assert.is_not_nil(brokers)
+    assert.is_same("b0-" .. confluent_bootstrap_server_adr, brokers[0].host)
+    assert.are.equal(brokers[0].port, 9092)
+    -- Check if return was assigned to cli metatable
+    assert.are.same({
+                  errcode = 0,
+                  id = 0,
+                  leader = 4,
+                  replicas = { [1] = 4, [2] = 5, [3] = 0},
+                  isr = { [1] = 4, [2] = 5, [3] = 0},
+                  }
+                    ,partitions[0])
+    -- Check if partitions were fetched correctly
+    assert.is_not_nil(cli.topic_partitions[confluent_topic])
+    -- Check if cli partitions metatable was set correctly
+  end)
+
+  it("setup producers correctly", function()
+    local p, err = producer:new(broker_list_sasl, client_config_sasl_plain)
+    assert.is_nil(err)
+    local offset, err = p:send(confluent_topic, key, message)
+    assert.is_nil(err)
+    assert.is_number(tonumber(offset))
+  end)
+end)


### PR DESCRIPTION
* Testing confluent cloud with existing library.

* Added the possibility to override "client_id" in the client constructor.


[KAG](https://konghq.atlassian.net/browse/KAG-5132)